### PR TITLE
[QU-4620] Add the radish consumers on the containers parameter

### DIFF
--- a/src/DependencyInjection/RadishExtension.php
+++ b/src/DependencyInjection/RadishExtension.php
@@ -32,6 +32,8 @@ class RadishExtension extends Extension
             $config['queues']
         ]);
 
+        $container->setParameter('radish.consumers', $config['consumers']);
+
         foreach ($config['consumers'] as $name => $consumer) {
             $this->loadConsumer($name, $consumer, $container);
         }


### PR DESCRIPTION
We need that in order to register the workers automatically, just by using the config file